### PR TITLE
Added Offsets for iOS 10.3.1, iPod Touch 6th Gen

### DIFF
--- a/v0rtexNonce/offsets.m
+++ b/v0rtexNonce/offsets.m
@@ -1636,8 +1636,19 @@ void load_offsets(void)
     	//10.3.1
     	if(!strcmp(version, "14E304"))
     	{
-    		LOG("10.3.1 - 14E304 offsets not found for %s", device);
-    		exit(1);
+    		OFFSET_ZONE_MAP                             = 0xfffffff007558478;
+            OFFSET_KERNEL_MAP                           = 0xfffffff0075b4050;
+            OFFSET_KERNEL_TASK                          = 0xfffffff0075b4048;
+            OFFSET_REALHOST                             = 0xfffffff00753aba0;
+            OFFSET_BZERO                                = 0xfffffff00708df80;
+            OFFSET_BCOPY                                = 0xfffffff00708ddc0;
+            OFFSET_COPYIN                               = 0xfffffff00718d3a8;
+            OFFSET_COPYOUT                              = 0xfffffff00718d59c;
+            OFFSET_IPC_PORT_ALLOC_SPECIAL               = 0xfffffff0070a611c;
+            OFFSET_IPC_KOBJECT_SET                      = 0xfffffff0070b9374;
+            OFFSET_IPC_PORT_MAKE_SEND                   = 0xfffffff0070a5c40;
+            OFFSET_IOSURFACEROOTUSERCLIENT_VTAB         = 0xfffffff006ef2d78;
+            OFFSET_ROP_ADD_X0_X0_0x10                   = 0xfffffff00651d174;
     	}
 
     	//10.3


### PR DESCRIPTION
I have tested these, and can verify that they work